### PR TITLE
byrbt抓取免费种子的代码已失效

### DIFF
--- a/app/libs/scrape.js
+++ b/app/libs/scrape.js
@@ -113,7 +113,7 @@ const _freeByrPT = async function (url, cookie) {
   if (d.body.innerHTML.indexOf('userdetails') === -1) {
     throw new Error('疑似登录状态失效, 请检查 Cookie');
   }
-  const state = d.querySelector('#share font[class]');
+  const state = d.querySelector('#share').querySelector('.free');
   return state && ['free', 'twoupfree'].indexOf(state.className) !== -1;
 };
 

--- a/app/libs/scrape.js
+++ b/app/libs/scrape.js
@@ -113,7 +113,7 @@ const _freeByrPT = async function (url, cookie) {
   if (d.body.innerHTML.indexOf('userdetails') === -1) {
     throw new Error('疑似登录状态失效, 请检查 Cookie');
   }
-  const state = d.querySelector('#share').querySelector('.free');
+  const state = d.querySelector('#share .free');
   return state && ['free', 'twoupfree'].indexOf(state.className) !== -1;
 };
 


### PR DESCRIPTION
byrbt的查询免费种子的功能似乎已失效：
![image-20230808001127746](https://raw.githubusercontent.com/YoghurtGuy/pic/main/picgo/image-20230808001127746.png)
新的代码可以解决这个问题：
免费：
![image-20230808001008687](https://raw.githubusercontent.com/YoghurtGuy/pic/main/picgo/image-20230808001008687.png)
非免费：
![image-20230808001247878](https://raw.githubusercontent.com/YoghurtGuy/pic/main/picgo/image-20230808001247878.png)