### PR TITLE
feat: FSM域名修改为 api.fsm.name

### DIFF
--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -704,7 +704,7 @@ const _getTorrentsWrapper = {
   'cinemaz.to': _getTorrentsExoticaZ,
   'privatehd.to': _getTorrentsExoticaZ,
   'rss.torrentleech.org': _getTorrentsTorrentLeech,
-  'fsm.name': _getTorrentsFSM,
+  'api.fsm.name': _getTorrentsFSM,
   'www.happyfappy.org': _getTorrentsHappyFappy
 };
 


### PR DESCRIPTION
目前 fsm.name RSS 301到了 api.fsm.name 不确定后期会不会移除, 直接追新,没写两个域名并列