### PR TITLE
Rss以及Client增加参数link，把种子详情链接传递给client类的addTorrent方法以及deleteTorrent方法增加判断删种规则是否启用通知

### DIFF
--- a/app/common/Rss.js
+++ b/app/common/Rss.js
@@ -212,7 +212,7 @@ class Rss {
             if (_torrent.name === bencodeInfo.name && _torrent.hash !== bencodeInfo.hash) {
               try {
                 this.addCount += 1;
-                await client.addTorrent(torrent.url, torrent.hash, true, this.uploadLimit, this.downloadLimit, _torrent.savePath, this.category);
+                await client.addTorrent(torrent.link,torrent.url, torrent.hash, true, this.uploadLimit, this.downloadLimit, _torrent.savePath, this.category);
                 await util.runRecord('INSERT INTO torrents (hash, name, size, rss_id, category, link, record_time, add_time, record_type, record_note) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                   [torrent.hash, torrent.name, torrent.size, this.id, this.category, torrent.link, moment().unix(), moment().unix(), 1, '辅种']);
                 await this.ntf.addTorrent(this._rss, client, torrent);
@@ -347,7 +347,7 @@ class Rss {
           const { filepath, hash } = await this._downloadTorrent(torrent.url, torrent.hash);
           await client.addTorrentByTorrentFile(filepath, hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
         } else {
-          await client.addTorrent(torrent.url, torrent.hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
+          await client.addTorrent(torrent.link,torrent.url, torrent.hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
         }
         try {
           await this.ntf.addTorrent(this._rss, client, torrent);

--- a/app/libs/client/de.js
+++ b/app/libs/client/de.js
@@ -18,7 +18,7 @@ exports.login = async function (username, clientUrl, password) {
   return res.headers['set-cookie'][0].substring(0, res.headers['set-cookie'][0].indexOf(';'));
 };
 
-exports.addTorrent = async function (clientUrl, cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, label) {
+exports.addTorrent = async function (link,clientUrl, cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, label) {
   let message = {
     method: 'POST',
     url: clientUrl + '/json',

--- a/app/libs/client/qb.js
+++ b/app/libs/client/qb.js
@@ -24,7 +24,7 @@ exports.login = async function (username, clientUrl, password) {
   }
 };
 
-exports.addTorrent = async function (clientUrl, cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, category, autoTMM, firstLastPiecePrio, paused) {
+exports.addTorrent = async function (link,clientUrl, cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, category, autoTMM, firstLastPiecePrio, paused) {
   const message = {
     url: clientUrl + '/api/v2/torrents/add',
     method: 'POST',
@@ -48,6 +48,9 @@ exports.addTorrent = async function (clientUrl, cookie, torrentUrl, isSkipChecki
   }
   if (autoTMM) {
     message.formData.autoTMM = '' + autoTMM;
+  }
+  if (paused) {
+    message.formData.tags = link;
   }
   const res = await util.requestPromise(message);
   logger.debug(clientUrl, '添加种子', torrentUrl, '\n返回信息', { body: res.body, statusCode: res.statusCode });

--- a/app/libs/client/tr.js
+++ b/app/libs/client/tr.js
@@ -22,7 +22,7 @@ exports.login = async function (username, clientUrl, password) {
   };
 };
 
-exports.addTorrentByTorrentFile = async function (clientUrl, cookie, filepath, isSkipChecking, uploadLimit, downloadLimit, savePath, category, autoTMM) {
+exports.addTorrentByTorrentFile = async function (link,clientUrl, cookie, filepath, isSkipChecking, uploadLimit, downloadLimit, savePath, category, autoTMM) {
   const message = {
     method: 'POST',
     url: clientUrl + '/transmission/rpc',


### PR DESCRIPTION
modified:   app/common/Client.js
modified:   app/common/Rss.js
modified:   app/libs/client/de.js
modified:   app/libs/client/qb.js
modified:   app/libs/client/tr.js

Rss以及Client增加参数link，把种子详情链接传递给client类的addTorrent方法
并在配置paused为true时在qb客户端把link传递给tags，方便qb客户端直接获取到种子详情链接。

Client的deleteTorrent方法增加判断删种规则是否启用通知，如规则配置不启用（前端未适配），则删种不触发消息通知。