### PR TITLE
Update Client.js  #trackerStatus字段获取

### DIFF
--- a/app/common/Client.js
+++ b/app/common/Client.js
@@ -528,7 +528,7 @@ class Client {
       try {
         if (await redis.get(`vertex:torrent_tracker:${torrent.hash}`)) continue;
         const sqlRes = await util.getRecord('SELECT * FROM torrents WHERE hash = ?', [torrent.hash]);
-        if (!sqlRes || !!sqlRes.delete_time) {
+        if (sqlRes && !!sqlRes.delete_time) {
           await redis.set(`vertex:torrent_tracker:${torrent.hash}`, 1);
           continue;
         };


### PR DESCRIPTION
采用原先的写法没办法获取非通过vertex rss添加种子的trackerstatus信息（因为外站大多通过irc进行加种，这时候sqlRes为空），会直接跳出循环，而不去获取这部分种子的trackerstatus。