### PR TITLE
feat: 添加对种子链接进行自定义正则替换的功能

### DIFF
--- a/app/common/Rss.js
+++ b/app/common/Rss.js
@@ -33,6 +33,9 @@ class Rss {
     this.category = rss.category;
     this.paused = rss.paused;
     this.autoTMM = rss.autoTMM;
+    this.useCustomRegex = rss.useCustomRegex;
+    this.regexStr = rss.regexStr;
+    this.replaceStr = rss.replaceStr;
     this.addCountPerHour = +rss.addCountPerHour || 20;
     this.addCount = 0;
     this.pushTorrentFile = rss.pushTorrentFile;
@@ -347,7 +350,17 @@ class Rss {
           const { filepath, hash } = await this._downloadTorrent(torrent.url, torrent.hash);
           await client.addTorrentByTorrentFile(filepath, hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
         } else {
-          await client.addTorrent(torrent.url, torrent.hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
+          if (this.useCustomRegex) {
+            const match = this.regexStr.match(/^\/(.*)\/([gimuy]*)$/);
+            if (match) {
+              const [_, pattern, flags] = match;
+              const regex = new RegExp(pattern, flags);
+              await client.addTorrent(torrent.url.replace(regex, this.replaceStr), torrent.hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
+            }
+          }
+          else {
+            await client.addTorrent(torrent.url, torrent.hash, false, this.uploadLimit, this.downloadLimit, savePath, category, this.autoTMM, this.paused);
+          }
         }
         try {
           await this.ntf.addTorrent(this._rss, client, torrent);

--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -768,6 +768,37 @@ const _getTorrentsKimoji = async function (rssUrl) {
   return torrents;
 };
 
+const _getTorrentsFappaizuri = async function (rssUrl) {
+  const rss = await parseXml(await _getRssContent(rssUrl, false));
+  const torrents = [];
+  const items = rss.rss.channel[0].item;
+  for (let i = 0; i < items.length; ++i) {
+    const torrent = {
+      size: 0,
+      name: '',
+      hash: '',
+      id: 0,
+      url: '',
+      link: ''
+    };
+    torrent.size = items[i].description[0].match(/Size: (\d+\.\d+ [MGKT]B)/);
+    if (torrent.size) {
+      torrent.size = util.calSize(...torrent.size[1].replace(/([MGKT])B/, '$1iB').split(' '));
+    } else {
+      torrent.size = 0;
+    }
+    torrent.name = items[i].title[0];
+    const url = items[i].link[0];
+    torrent.id = url.match(/id=(\d+)/)[1];
+    torrent.link = 'https://fappaizuri.me/torrents-details.php?id=' + torrent.id;
+    torrent.url = url;
+    torrent.hash = 'fappaizuri' + torrent.id + 'fappaizuri';
+    torrent.pubTime = moment(items[i].pubDate[0]).unix();
+    torrents.push(torrent);
+  }
+  return torrents;
+};
+
 const _getTorrentsWrapper = {
   'filelist.io': _getTorrentsFileList,
   'blutopia.cc': _getTorrentsUnit3D2,
@@ -791,12 +822,15 @@ const _getTorrentsWrapper = {
   'cinemaz.to': _getTorrentsExoticaZ,
   'privatehd.to': _getTorrentsExoticaZ,
   'rss.torrentleech.org': _getTorrentsTorrentLeech,
+  'rss24h.torrentleech.org': _getTorrentsTorrentLeech,
   'fsm.name': _getTorrentsFSM,
   'www.happyfappy.org': _getTorrentsHappyFappy,
   'fearnopeer.com': _getTorrentsUnit3D2,
   'jpopsuki.eu': _getTorrentsGazelle,
   'dicmusic.com': _getTorrentsGazelle,
-  'greatposterwall.com': _getTorrentsGazelle
+  'greatposterwall.com': _getTorrentsGazelle,
+  'libble.me': _getTorrentsGazelle,
+  'fappaizuri.me': _getTorrentsFappaizuri
 };
 
 exports.getTorrents = async function (rssUrl) {

--- a/webui/src/pages/task/Rss.vue
+++ b/webui/src/pages/task/Rss.vue
@@ -276,6 +276,28 @@
           <a-checkbox v-model:checked="rss.pushTorrentFile">推送种子文件</a-checkbox>
         </a-form-item>
         <a-form-item
+          label="自定义正则替换"
+          v-if="!rss.pushTorrentFile"
+          name="useCustomRegex"
+          extra="对种子下载链接进行自定义正则表达式替换, 仅在推送方式为推送种子下载链接时生效。不完全理解本功能请勿设置, 不恰当的配置可能导致你的账号被ban。">
+          <a-checkbox v-model:checked="rss.useCustomRegex">使用自定义正则</a-checkbox>
+        </a-form-item>
+        <a-form-item
+          label="正则表达式"
+          v-if="(!rss.pushTorrentFile) && rss.useCustomRegex"
+          name="regexStr"
+          extra="格式: /pattern/flags"
+          :rules="[{ required: true, message: '${label}不可为空! ' }]">
+          <a-input size="small" v-model:value="rss.regexStr"/>
+        </a-form-item>
+        <a-form-item
+          label="替换为"
+          v-if="(!rss.pushTorrentFile) && rss.useCustomRegex"
+          name="replaceStr"
+          :rules="[{ required: true, message: '${label}不可为空! ' }]">
+          <a-input size="small" v-model:value="rss.replaceStr"/>
+        </a-form-item>
+        <a-form-item
           label="拒绝规则"
           name="rejectRules"
           extra="拒绝规则, 种子状态符合其中一个时即触发拒绝种子操作">


### PR DESCRIPTION
测试过可以正常使用

只会在最后正式把链接提交到下载器的时候进行替换，其余的下载种子获取种子大小/种子名称/hash等过程都不会调用。