### PR TITLE
fix(piggo): Avoid hitting piggo's WAF by sending cookie

### DIFF
--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -21,7 +21,8 @@ const _getRssContent = async function (rssUrl, suffix = true) {
     body = cache;
   } else {
     let url = rssUrl;
-    if (suffix) {
+    let isPig = rssUrl.includes("https://piggo.me/");
+    if (suffix && !isPig) {
       url += (rssUrl.indexOf('?') === -1 ? '?' : '&') + '____=' + Math.random();
     }
     let res;
@@ -32,6 +33,16 @@ const _getRssContent = async function (rssUrl, suffix = true) {
           cookie: global.runningSite.SoulVoice.cookie
         }
       }, true);
+    } else if (isPig && global.runningSite.PIGGO) {
+      res = await util.requestPromise(
+        {
+          url,
+          headers: {
+            cookie: global.runningSite.PIGGO.cookie,
+          },
+        },
+        true
+      );
     } else {
       res = await util.requestPromise(url, true);
     }

--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -21,7 +21,7 @@ const _getRssContent = async function (rssUrl, suffix = true) {
     body = cache;
   } else {
     let url = rssUrl;
-    let isPig = rssUrl.includes("https://piggo.me/");
+    const isPig = rssUrl.includes('https://piggo.me/');
     if (suffix && !isPig) {
       url += (rssUrl.indexOf('?') === -1 ? '?' : '&') + '____=' + Math.random();
     }
@@ -38,8 +38,8 @@ const _getRssContent = async function (rssUrl, suffix = true) {
         {
           url,
           headers: {
-            cookie: global.runningSite.PIGGO.cookie,
-          },
+            cookie: global.runningSite.PIGGO.cookie
+          }
         },
         true
       );

--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -33,16 +33,6 @@ const _getRssContent = async function (rssUrl, suffix = true) {
           cookie: global.runningSite.SoulVoice.cookie
         }
       }, true);
-    } else if (isPig && global.runningSite.PIGGO) {
-      res = await util.requestPromise(
-        {
-          url,
-          headers: {
-            cookie: global.runningSite.PIGGO.cookie
-          }
-        },
-        true
-      );
     } else {
       res = await util.requestPromise(url, true);
     }


### PR DESCRIPTION

猪猪的WAF能阻断RSS请求，但是网络测试工具就能过。只要不改url就可以过。不过我不知道修改url的目的是什么。可能会搞坏猪猪的其他功能。。。

代码写得不好。请见谅和指正！