### PR TITLE
fix(pterclub): Fix the seeding size stats

### DIFF
--- a/app/libs/site/PTerClub.js
+++ b/app/libs/site/PTerClub.js
@@ -31,14 +31,9 @@ class Site {
     // 下载
     info.leeching = +document.querySelector('img[class=arrowdown]').nextSibling.nodeValue.trim();
     // 做种体积
-    const seedingDocument = await this._getDocument(`${this.index}getusertorrentlist.php?do_ajax=1&userid=${info.uid}&type=seeding`);
-    const seedingTorrent = [...seedingDocument.querySelectorAll('tr')];
-    seedingTorrent.shift();
-    info.seedingSize = 0;
-    for (const torrent of seedingTorrent) {
-      const siteStr = torrent.childNodes[5].innerHTML.replace('<br>', ' ').replace(/([KMGTP])B/, '$1iB');
-      info.seedingSize += util.calSize(...siteStr.split(' '));
-    }
+    const seedingDocument = await this._getDocument(`${this.index}userdetails.php?id=${info.uid}`, true);
+    const seedingSize = (seedingDocument.match(/做种大小.+[^\d](\d+\.\d+ [KMGTP]B)/) || [0, '2 B'])[1].replace(/([KMGTP])B/, '$1iB');
+    info.seedingSize = util.calSize(...seedingSize.split(' '));
     return info;
   };
 


### PR DESCRIPTION
pterclub的做种体积是错的。推测是因为现有逻辑只拉了一页的做种列表，所以统计不全。新逻辑从用户信息页面拉取现成的数字。还有好多其他站点也用类似的逻辑也有类似的问题。以后可以一一适配。

错误的数据：
![CleanShot 2024-09-13 at 08 50 36](https://github.com/user-attachments/assets/5179e16e-faca-4fe7-abd1-410eb0804bc8)

正确的数据：
![CleanShot 2024-09-13 at 09 12 40](https://github.com/user-attachments/assets/f42508e3-46f7-4ad7-a8ee-60b7c34ddc17)

用户页面的html：
```
<tr><td width="1%" class="rowhead nowrap" valign="top" align="right">做种大小</td><td width="99%" class="rowfollow" valign="top" align="left">22.540 TB</td></tr>
```

developer console的测试：
![CleanShot 2024-09-13 at 09 10 09](https://github.com/user-attachments/assets/8f73d320-6a94-4e75-a19d-54a2a942af2e)



