### PR TITLE
fix: 修复Deluge添加种子失败的问题

### DIFF
--- a/app/libs/client/de.js
+++ b/app/libs/client/de.js
@@ -1,5 +1,6 @@
 const util = require('../util');
 const fs = require('fs');
+const path = require('path');
 
 exports.login = async function (username, clientUrl, password) {
   const message = {
@@ -19,7 +20,7 @@ exports.login = async function (username, clientUrl, password) {
   return res.headers['set-cookie'][0].substring(0, res.headers['set-cookie'][0].indexOf(';'));
 };
 
-exports.addTorrent = async function (clientUrl, cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, label) {
+exports.addTorrent = async function (clientUrl, cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, label, autoTMM, firstLastPiecePrio, paused) {
   let message = {
     method: 'POST',
     url: clientUrl + '/json',
@@ -27,120 +28,144 @@ exports.addTorrent = async function (clientUrl, cookie, torrentUrl, isSkipChecki
     gzip: true,
     body: {
       id: 0,
-      method: 'web.download_torrent_from_url',
-      params: [
-        torrentUrl,
-        ''
-      ]
-    },
-    headers: {
-      cookie
-    }
-  };
-  let res = await util.requestPromise(message);
-  const torrentPath = res.body.result;
-  message = {
-    method: 'POST',
-    url: clientUrl + '/json',
-    json: true,
-    gzip: true,
-    body: {
-      id: 0,
-      method: 'web.add_torrents',
-      params: [
-        [
+      method: 'core.add_torrent_url',
+      params:
+        [torrentUrl,
           {
-            path: torrentPath,
-            options: {
-              file_priorities: [
-                1
-              ],
-              add_paused: false,
-              sequential_download: false,
-              pre_allocate_storage: false,
-              move_completed: false,
-              max_connections: -1,
-              max_download_speed: downloadLimit,
-              max_upload_slots: -1,
-              max_upload_speed: uploadLimit,
-              prioritize_first_last_pieces: false,
-              seed_mode: isSkipChecking,
-              super_seeding: false
-            }
+            sequential_download: false,
+            pre_allocate_storage: false,
+            move_completed: false,
+            max_connections: -1,
+            max_download_speed: downloadLimit ? (downloadLimit / 1024) : -1,
+            max_upload_slots: -1,
+            max_upload_speed: uploadLimit ? (uploadLimit / 1024) : -1,
+            prioritize_first_last_pieces: firstLastPiecePrio,
+            seed_mode: isSkipChecking,
+            super_seeding: false
           }
         ]
-      ]
     },
     headers: {
       cookie
     }
   };
-  if (savePath) {
-    message.body.params[0][0].options.download_location = savePath;
+  if (paused) {
+    message.body.params[1].add_paused = paused;
   }
-  if (label) {
-    message.body.params[0][0].options.label = label;
+  if (savePath) {
+    message.body.params[1].download_location = savePath;
   }
   res = await util.requestPromise(message);
+  if (label) {
+    message = {
+      method: 'POST',
+      url: clientUrl + '/json',
+      json: true,
+      gzip: true,
+      body: {
+        method: 'label.set_torrent',
+        params: [res.body.result, label],
+        id: 0
+      },
+      headers: {
+        cookie
+      }
+    };
+    res = await util.requestPromise(message);
+    if (res.body.error && (res.body.error.message.indexOf('Unknown Label') !== -1)) {
+      add_label_message = {
+        method: 'POST',
+        url: clientUrl + '/json',
+        json: true,
+        gzip: true,
+        body: {
+          method: 'label.add',
+          params: [label],
+          id: 0
+        },
+        headers: {
+          cookie
+        }
+      };
+      res = await util.requestPromise(add_label_message);
+      res = await util.requestPromise(message);
+    }
+  }
   return res;
 };
 
-exports.addTorrentByTorrentFile = async function (clientUrl, cookie, filepath, isSkipChecking, uploadLimit, downloadLimit, savePath, label) {
+exports.addTorrentByTorrentFile = async function (clientUrl, cookie, filepath, isSkipChecking, uploadLimit, downloadLimit, savePath, label, autoTMM, firstLastPiecePrio, paused) {
   let message = {
-    url: clientUrl + '/upload',
-    method: 'POST',
-    headers: {
-      cookie
-    },
-    formData: {
-      file: fs.createReadStream(filepath)
-    }
-  };
-  let res = await util.requestPromise(message);
-  const torrentPath = JSON.parse(res.body).files[0];
-  message = {
     method: 'POST',
     url: clientUrl + '/json',
     json: true,
     gzip: true,
     body: {
       id: 0,
-      method: 'web.add_torrents',
+      method: 'core.add_torrent_file',
       params: [
-        [
-          {
-            path: torrentPath,
-            options: {
-              file_priorities: [
-                1
-              ],
-              add_paused: false,
-              sequential_download: false,
-              pre_allocate_storage: false,
-              move_completed: false,
-              max_connections: -1,
-              max_download_speed: downloadLimit,
-              max_upload_slots: -1,
-              max_upload_speed: uploadLimit,
-              prioritize_first_last_pieces: false,
-              seed_mode: isSkipChecking,
-              super_seeding: false
-            }
-          }
+        path.basename(filepath),
+        fs.readFileSync(filepath).toString('base64'),
+        {
+          sequential_download: false,
+          pre_allocate_storage: false,
+          move_completed: false,
+          max_connections: -1,
+          max_download_speed: downloadLimit ? (downloadLimit / 1024) : -1,
+          max_upload_slots: -1,
+          max_upload_speed: uploadLimit ? (uploadLimit / 1024) : -1,
+          prioritize_first_last_pieces: firstLastPiecePrio,
+          seed_mode: isSkipChecking,
+          super_seeding: false
+        }
         ]
-      ]
     },
     headers: {
       cookie
     }
   };
-  if (savePath) {
-    message.body.params[0][0].options.download_location = savePath;
+  if (paused) {
+    message.body.params[2].add_paused = paused;
   }
-  if (label) {
-    message.body.params[0][0].options.label = label;
+  if (savePath) {
+    message.body.params[2].download_location = savePath;
   }
   res = await util.requestPromise(message);
+  if (label) {
+    message = {
+      method: 'POST',
+      url: clientUrl + '/json',
+      json: true,
+      gzip: true,
+      body: {
+        method: 'label.set_torrent',
+        params: [res.body.result, label],
+        id: 0
+      },
+      headers: {
+        cookie
+      }
+    };
+    res = await util.requestPromise(message);
+    if (res.body.error && (res.body.error.message.indexOf('Unknown Label') !== -1)) {
+      add_label_message = {
+        method: 'POST',
+        url: clientUrl + '/json',
+        json: true,
+        gzip: true,
+        body: {
+          method: 'label.add',
+          params: [label],
+          id: 0
+        },
+        headers: {
+          cookie
+        }
+      };
+      res = await util.requestPromise(add_label_message);
+      res = await util.requestPromise(message);
+    }
+  }
   return res;
 };
 
@@ -236,7 +261,30 @@ exports.reannounceTorrent = async function (clientUrl, cookie, hash) {
   return res;
 };
 
+exports.pauseTorrent = async function (clientUrl, cookie, hash) {
+  const message = {
+    method: 'POST',
+    url: clientUrl + '/json',
+    json: true,
+    gzip: true,
+    body: {
+      id: 0,
+      method: 'core.pause_torrent',
+      params: [
+        [hash]
+      ]
+    },
+    headers: {
+      cookie
+    }
+  };
+  const res = await util.requestPromise(message);
+  return res;
+};
+
 exports.deleteTorrent = async function (clientUrl, cookie, hash, isDeleteFiles) {
+  // 玄学，Deluge删除种子不先暂停有可能会丢最后一次汇报的流量
+  await exports.pauseTorrent(clientUrl, cookie, hash);
   const message = {
     method: 'POST',
     url: clientUrl + '/json',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/468949b7-bb87-4668-a3f1-c55a15758e67)

web.add_torrents已经无法使用，改为用core.add_torrent_url和core.add_torrent_file添加种子。label无法在core.add_torrent中直接指定，用label.set_torrent单独进行设置。

另外Deluge似乎有force reannounce依然受内置周期影响的问题，只有暂停才能强制进行汇报，很可能是bug。这一现象导致直接删除种子如果站点没有二级统计机制就会漏掉最后一次汇报的上传量，因此我设置了先暂停再删除。