### PR TITLE
feat: 修改Luminance站点RSS逻辑, 添加Luminance站点抓免, 通知工具增加种子hash字段

### DIFF
--- a/app/libs/client/de.js
+++ b/app/libs/client/de.js
@@ -283,7 +283,7 @@ exports.pauseTorrent = async function (clientUrl, cookie, hash) {
 };
 
 exports.deleteTorrent = async function (clientUrl, cookie, hash, isDeleteFiles) {
-  // 玄学，Deluge删除种子不先暂停有可能会丢最后一次汇报的流量
+  // Deluge删除种子不先暂停有可能会丢最后一次汇报的流量
   await exports.pauseTorrent(clientUrl, cookie, hash);
   const message = {
     method: 'POST',

--- a/app/libs/client/qb.js
+++ b/app/libs/client/qb.js
@@ -101,6 +101,7 @@ exports.addTorrentTag = async function (clientUrl, cookie, hash, tag) {
 };
 
 exports.deleteTorrent = async function (clientUrl, cookie, hash, isDeleteFiles) {
+  await exports.pauseTorrent(clientUrl, cookie, hash);
   const message = {
     url: clientUrl + '/api/v2/torrents/delete',
     method: 'POST',

--- a/app/libs/push/ntfy.js
+++ b/app/libs/push/ntfy.js
@@ -55,6 +55,7 @@ class Ntfy {
     const desp = `RSS 任务: ${rss.alias}\n` +
       `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       '请确认 Rss 站点是否支持抓取免费或抓取 HR, 若确认无问题, 请前往 Vertex 日志页面查看详细原因';
     await this.pushNtfy(title, desp);
   };
@@ -65,7 +66,8 @@ class Ntfy {
       `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
-      `种子大小: ${util.formatSize(torrent.size)}`;
+      `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}` ;
     await this.pushNtfy(title, desp);
   };
 
@@ -169,6 +171,7 @@ class Ntfy {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       '详细原因请前往 Vertex 日志页面查看';
     await this.pushNtfy(title, desp);
   };
@@ -180,6 +183,7 @@ class Ntfy {
       `下载器名: ${client.alias || '未定义'}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `其它信息: ${note}`;
     await this.pushNtfy(title, desp);
   };
@@ -190,6 +194,7 @@ class Ntfy {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `已完成量: ${util.formatSize(torrent.completed)}\n` +
       `种子状态: ${torrent.state}\n` +
       `添加时间: ${moment(torrent.addedTime * 1000).format('YYYY-MM-DD HH:mm:ss')}\n` +
@@ -210,6 +215,7 @@ class Ntfy {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `已完成量: ${util.formatSize(torrent.completed)}\n` +
       `种子状态: ${torrent.completed.state}\n` +
       `所属分类: ${torrent.category}\n` +
@@ -225,7 +231,8 @@ class Ntfy {
     const title = '重新汇报种子';
     const desp = `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `种子名称: ${torrent.name}\n` + 
+      `种子 hash: ${torrent.hash}`;
     await this.pushNtfy(title, desp);
   };
 
@@ -233,7 +240,8 @@ class Ntfy {
     const title = '重新汇报种子失败';
     const desp = `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `种子名称: ${torrent.name}\n` + 
+      `种子 hash: ${torrent.hash}`;
     await this.pushNtfy(title, desp);
   };
 

--- a/app/libs/push/slack.js
+++ b/app/libs/push/slack.js
@@ -80,6 +80,7 @@ class Slack {
     const desp = `*RSS 任务*: ${rss.alias}\n` +
       `*当前时间*: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `*种子名称*: ${torrent.name}\n` +
+      `*种子 hash*: ${torrent.hash}\n` +
       '请确认 Rss 站点是否支持抓取免费或抓取 HR, 若确认无问题, 请前往 Vertex 日志页面查看详细原因';
     await this.pushSlack(title, desp);
   };
@@ -90,7 +91,8 @@ class Slack {
       `*当前时间*: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `*下载器名*: ${client.alias}\n` +
       `*种子名称*: ${torrent.name}\n` +
-      `*种子大小*: ${util.formatSize(torrent.size)}`;
+      `*种子大小*: ${util.formatSize(torrent.size)}\n` +
+      `*种子 hash*: ${torrent.hash}`;
     await this.pushSlack(title, desp);
   };
 
@@ -187,6 +189,7 @@ class Slack {
       `*下载器名*: ${client.alias}\n` +
       `*种子名称*: ${torrent.name}\n` +
       `*种子大小*: ${util.formatSize(torrent.size)}\n` +
+      `*种子 hash*: ${torrent.hash}\n` +
       '详细原因请前往 Vertex 日志页面查看';
     await this.pushSlack(title, desp);
   };
@@ -198,6 +201,7 @@ class Slack {
       `*下载器名*: ${client.alias || '未定义'}\n` +
       `*种子名称*: ${torrent.name}\n` +
       `*种子大小*: ${util.formatSize(torrent.size)}\n` +
+      `*种子 hash*: ${torrent.hash}\n` +
       `*其它信息*: ${note}`;
     await this.pushSlack(title, desp);
   };
@@ -208,6 +212,7 @@ class Slack {
       `*下载器名*: ${client.alias}\n` +
       `*种子名称*: ${torrent.name}\n` +
       `*种子大小*: ${util.formatSize(torrent.size)}\n` +
+      `*种子 hash*: ${torrent.hash}\n` +
       `*已完成量*: ${util.formatSize(torrent.completed)}\n` +
       `*种子状态*: ${torrent.state}\n` +
       `*添加时间*: ${moment(torrent.addedTime * 1000).format('YYYY-MM-DD HH:mm:ss')}\n` +
@@ -228,6 +233,7 @@ class Slack {
       `*下载器名*: ${client.alias}\n` +
       `*种子名称*: ${torrent.name}\n` +
       `*种子大小*: ${util.formatSize(torrent.size)}\n` +
+      `*种子 hash*: ${torrent.hash}\n` +
       `*已完成量*: ${util.formatSize(torrent.completed)}\n` +
       `*种子状态*: ${torrent.completed.state}\n` +
       `*所属分类*: ${torrent.category}\n` +
@@ -243,7 +249,8 @@ class Slack {
     const title = '重新汇报种子';
     const desp = `*当前时间*: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `*下载器名*: ${client.alias}\n` +
-      `*种子名称*: ${torrent.name}`;
+      `*种子名称*: ${torrent.name}\n` +
+      `*种子 hash*: ${torrent.hash}`;
     await this.pushSlack(title, desp);
   };
 
@@ -251,7 +258,8 @@ class Slack {
     const title = '重新汇报种子失败';
     const desp = `*当前时间*: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `*种子名称*: ${torrent.name}\n` +
+      `*种子 hash*: ${torrent.hash}`;
     await this.pushSlack(title, desp);
   };
 

--- a/app/libs/push/telegram.js
+++ b/app/libs/push/telegram.js
@@ -77,6 +77,7 @@ class Telegram {
     const desp = `RSS 任务: ${rss.alias}\n` +
       `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       '请确认 Rss 站点是否支持抓取免费或抓取 HR, 若确认无问题, 请前往 Vertex 日志页面查看详细原因';
     await this.pushTelegram(title, desp);
   };
@@ -87,7 +88,8 @@ class Telegram {
       `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
-      `种子大小: ${util.formatSize(torrent.size)}`;
+      `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}`;
     await this.pushTelegram(title, desp);
   };
 
@@ -191,6 +193,7 @@ class Telegram {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       '详细原因请前往 Vertex 日志页面查看';
     await this.pushTelegram(title, desp);
   };
@@ -202,6 +205,7 @@ class Telegram {
       `下载器名: ${client.alias || '未定义'}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `其它信息: ${note}`;
     await this.pushTelegram(title, desp);
   };
@@ -212,6 +216,7 @@ class Telegram {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `已完成量: ${util.formatSize(torrent.completed)}\n` +
       `种子状态: ${torrent.state}\n` +
       `添加时间: ${moment(torrent.addedTime * 1000).format('YYYY-MM-DD HH:mm:ss')}\n` +
@@ -232,6 +237,7 @@ class Telegram {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `已完成量: ${util.formatSize(torrent.completed)}\n` +
       `种子状态: ${torrent.completed.state}\n` +
       `所属分类: ${torrent.category}\n` +
@@ -247,7 +253,8 @@ class Telegram {
     const title = '重新汇报种子';
     const desp = `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}`;
     await this.pushTelegram(title, desp);
   };
 
@@ -255,7 +262,8 @@ class Telegram {
     const title = '重新汇报种子失败';
     const desp = `当前时间: ${moment().format('YYYY-MM-DD HH:mm:ss')}\n` +
       `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}`;
     await this.pushTelegram(title, desp);
   };
 

--- a/app/libs/push/wechat.js
+++ b/app/libs/push/wechat.js
@@ -173,6 +173,7 @@ class Wechat {
     const text = '抓取失败 ' + moment().format('YYYY-MM-DD HH:mm:ss');
     const desp = `Rss 任务: ${rss.alias}\n` +
       `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       '请确认 Rss 站点是否支持抓取免费或抓取 HR, 若确认无问题, 请前往 Vertex 日志页面查看详细原因';
     await this.pushWeChat(text, desp);
   }
@@ -182,7 +183,8 @@ class Wechat {
     const desp = `Rss 任务: ${rss.alias}\n` +
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
-      `种子大小: ${util.formatSize(torrent.size)}`;
+      `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}`;
     await this.pushWeChat(text, desp);
   };
 
@@ -305,6 +307,7 @@ class Wechat {
       `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       '详细原因请前往 Vertex 日志页面查看';
     await this.pushWeChat(text, desp);
   };
@@ -315,6 +318,7 @@ class Wechat {
       `下载器名: ${client.alias || '未定义'}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       note;
     await this.pushWeChat(text, desp);
   };
@@ -324,6 +328,7 @@ class Wechat {
     const desp = `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `已完成量: ${util.formatSize(torrent.completed)}\n` +
       `种子状态: ${torrent.state}\n` +
       `添加时间: ${moment(torrent.addedTime * 1000).format('YYYY-MM-DD HH:mm:ss')}\n` +
@@ -344,6 +349,7 @@ class Wechat {
     const desp = `下载器名: ${client.alias}\n` +
       `种子名称: ${torrent.name}\n` +
       `种子大小: ${util.formatSize(torrent.size)}\n` +
+      `种子 hash: ${torrent.hash}\n` +
       `已完成量: ${util.formatSize(torrent.completed)}\n` +
       `种子状态: ${torrent.completed.state}\n` +
       `所属分类: ${torrent.category}\n` +
@@ -358,14 +364,16 @@ class Wechat {
   async reannounceTorrent (client, torrent) {
     const text = '重新汇报种子 ' + moment().format('YYYY-MM-DD HH:mm:ss');
     const desp = `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}`;
     await this.pushWeChat(text, desp);
   };
 
   async reannounceTorrentError (client, torrent) {
     const text = '重新汇报种子失败 ' + moment().format('YYYY-MM-DD HH:mm:ss');
     const desp = `下载器名: ${client.alias}\n` +
-      `种子名称: ${torrent.name}`;
+      `种子名称: ${torrent.name}\n` +
+      `种子 hash: ${torrent.hash}`;
     await this.pushWeChat(text, desp);
   };
 

--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -302,7 +302,7 @@ const _getTorrentsTorrentDB = async function (rssUrl) {
   return torrents;
 };
 
-const _getTorrentsEmpornium = async function (rssUrl) {
+const _getTorrentsLuminance = async function (rssUrl) {
   const rss = await parseXml(await _getRssContent(rssUrl));
   const torrents = [];
   const items = rss.rss.channel[0].item;
@@ -320,26 +320,11 @@ const _getTorrentsEmpornium = async function (rssUrl) {
     torrent.link = link;
     torrent.id = link.substring(link.indexOf('?id=') + 4);
     torrent.url = items[i].enclosure[0].$.url;
-    const cache = await redis.get(`vertex:hash:${torrent.url}`);
-    if (cache) {
-      const _torrent = JSON.parse(cache);
-      torrent.hash = _torrent.hash;
-      torrent.size = _torrent.size;
-    } else {
-      try {
-        const { hash, size } = await exports.getTorrentNameByBencode(torrent.url);
-        torrent.hash = hash;
-        torrent.size = size;
-        await redis.set(`vertex:hash:${torrent.url}`, JSON.stringify(torrent));
-      } catch (e) {
-        await redis.set(`vertex:hash:${torrent.url}`, JSON.stringify({ hash: 'emp' + moment().unix() + 'emp', size: 0 }));
-        throw e;
-      }
-    }
+    torrent.hash = items[i].torrent[0].infoHash[0];
+    torrent.size = items[i].torrent[0].contentLength[0];
     torrent.pubTime = moment(items[i].pubDate[0]).unix();
     torrents.push(torrent);
   }
-
   return torrents;
 };
 
@@ -605,7 +590,7 @@ const _getTorrentsLearnFlakes = async function (rssUrl) {
   return torrents;
 };
 
-const _getTorrentsExoticaZ = async function (rssUrl) {
+const _getTorrentsAvistaZ = async function (rssUrl) {
   const rss = await parseXml(await _getRssContent(rssUrl));
   const torrents = [];
   const items = rss.rss.channel[0].item;
@@ -832,7 +817,10 @@ const _getTorrentsWrapper = {
   'kimoji.club': _getTorrentsKimoji,
   'torrentdb.net': _getTorrentsTorrentDB,
   'uhdbits.org': _getTorrentsGazelle,
-  'www.empornium.is': _getTorrentsEmpornium,
+  'www.empornium.is': _getTorrentsLuminance,
+  'www.empornium.sx': _getTorrentsLuminance,
+  'www.pixelcove.me': _getTorrentsLuminance,
+  'www.cathode-ray.tube':  _getTorrentsLuminance,
   'www.skyey2.com': _getTorrentsSkyeySnow,
   'hdbits.org': _getTorrentsHDBits,
   'beyond-hd.me': _getTorrentsBeyondHD,
@@ -842,10 +830,10 @@ const _getTorrentsWrapper = {
   'iptorrents.com': _getTorrentsIPTorrents,
   'mikanani.me': _getTorrentsMikanProject,
   'learnflakes.net': _getTorrentsLearnFlakes,
-  'exoticaz.to': _getTorrentsExoticaZ,
-  'avistaz.to': _getTorrentsExoticaZ,
-  'cinemaz.to': _getTorrentsExoticaZ,
-  'privatehd.to': _getTorrentsExoticaZ,
+  'exoticaz.to': _getTorrentsAvistaZ,
+  'avistaz.to': _getTorrentsAvistaZ,
+  'cinemaz.to': _getTorrentsAvistaZ,
+  'privatehd.to': _getTorrentsAvistaZ,
   'rss.torrentleech.org': _getTorrentsTorrentLeech,
   'rss24h.torrentleech.org': _getTorrentsTorrentLeech,
   'fsm.name': _getTorrentsFSM,

--- a/app/libs/scrape.js
+++ b/app/libs/scrape.js
@@ -159,6 +159,15 @@ const _freeHUDBT = async function (url, cookie) {
   return state;
 };
 
+const _freeLuminance = async function (url, cookie) {
+  const d = await getDocument(url, cookie);
+  if (d.body.innerHTML.indexOf('nav_userinfo') === -1) {
+    throw new Error('疑似登录状态失效, 请检查 Cookie');
+  }
+  const state = d.querySelector('img[alt="Freeleech"]');
+  return state;
+};
+
 const freeWrapper = {
   'pt.btschool.club': _free,
   'club.hares.top': _freeHaresClub,
@@ -196,7 +205,11 @@ const freeWrapper = {
   'byr.pt': _freeByrPT,
   'hhanclub.top': _freeHHanClub,
   'zeus.hamsters.space': _freeHUDBT,
-  'hudbt.hust.edu.cn': _freeHUDBT
+  'hudbt.hust.edu.cn': _freeHUDBT,
+  'www.empornium.is': _freeLuminance,
+  'www.empornium.sx': _freeLuminance,
+  'www.pixelcove.me': _freeLuminance,
+  'www.cathode-ray.tube':  _freeLuminance,
 };
 
 const _hr = async function (url, cookie) {


### PR DESCRIPTION
Luminance RSS里自带hash和大小不用下载种子，把下载种子的流程去掉了，另加了抓免

通知工具对种子相关操作都增加了通知种子hash

qb删种前先暂停可以避免卡站点的同时下载种子数量限制，想想把这个功能给qb也加上了