### PR TITLE
fix: 修复葡萄RSS获取失败问题

### DIFF
--- a/app/libs/rss.js
+++ b/app/libs/rss.js
@@ -126,18 +126,23 @@ const _getTorrentsPuTao = async function (rssUrl) {
       url: '',
       link: ''
     };
-    const size = items[i].title[0].match(/\[\d+\.\d+ [KMGT]B\]/)[0]?.match(/\d+\.\d+ [KMGT]B/)[0];
+    const size = items[i].title[0].match(/\[\d+\.\d+ [KMGT]B\]/)?.[0].match(/\d+\.\d+ [KMGT]B/)?.[0];
     const map = {
       KB: 1000,
       MB: 1000 * 1000,
       GB: 1000 * 1000 * 1000,
       TB: 1000 * 1000 * 1000 * 1000
     };
-    torrent.size = size.match(/(\d*\.\d*|\d*) (GB|MB|TB|KB)/);
-    torrent.size = parseFloat(torrent.size[1]) * map[torrent.size[2]];
+    const matchResult = size?.match(/(\d*\.\d*|\d*) (GB|MB|TB|KB)/);
+    if (matchResult) {
+      torrent.size = parseFloat(matchResult[1]) * map[matchResult[2]];
+    }
+    else {
+      torrent.size = 0;
+    }
     torrent.name = items[i].title[0];
     const link = items[i].link[0];
-    torrent.link = link.substring(0, link.indexOf('&passkey='));
+    torrent.link = link.substring(0, link.indexOf('&passkey=')).replace('download', 'details');
     torrent.id = torrent.link.substring(link.indexOf('?id=') + 4);
     torrent.url = link;
     torrent.hash = items[i].guid[0]._ || items[i].guid[0];
@@ -170,7 +175,7 @@ const _getTorrentsFileList = async function (rssUrl) {
     const regRes = size.match(/Size: (\d*\.\d*|\d*) (GB|MB|TB|KB)/);
     torrent.size = parseFloat(regRes[1]) * map[regRes[2]];
     torrent.name = items[i].title[0].replace(/\n/, ' ');
-    const link = items[i].link[0].match(/https:\/\/filelist.io\/download\.php\?id=\d*/)[0].replace('download', 'detailes');
+    const link = items[i].link[0].match(/https:\/\/filelist.io\/download\.php\?id=\d*/)[0].replace('download', 'details');
     torrent.link = link;
     torrent.id = link.substring(link.indexOf('?id=') + 4);
     torrent.hash = 'fakehash' + torrent.id + 'fakehash';

--- a/app/libs/scrape.js
+++ b/app/libs/scrape.js
@@ -159,6 +159,24 @@ const _freeHUDBT = async function (url, cookie) {
   return state;
 };
 
+const _freePuTao = async function (url, cookie) {
+  const d = await getDocument(url, cookie);
+  if (d.body.innerHTML.indexOf('userdetails') === -1) {
+    throw new Error('疑似登录状态失效, 请检查 Cookie');
+  }
+  const state = d.querySelector('b font[class]');
+  return state && ['free', 'twoupfree'].indexOf(state.className) !== -1;
+};
+
+const _freeBitPorn = async function (url, cookie) {
+  const d = await getDocument(url, cookie);
+  if (d.body.innerHTML.indexOf('userdetails') === -1) {
+    throw new Error('疑似登录状态失效, 请检查 Cookie');
+  }
+  const state = Array.from(d.querySelectorAll('span.stic2')).some(el => el.textContent.trim() === '2X Free' || el.textContent.trim() === 'Free');
+  return state;
+};
+
 const _freeLuminance = async function (url, cookie) {
   const d = await getDocument(url, cookie);
   if (d.body.innerHTML.indexOf('nav_userinfo') === -1) {
@@ -206,6 +224,8 @@ const freeWrapper = {
   'hhanclub.top': _freeHHanClub,
   'zeus.hamsters.space': _freeHUDBT,
   'hudbt.hust.edu.cn': _freeHUDBT,
+  'bitporn.eu': _freeBitPorn,
+  'pt.sjtu.edu.cn': _freePuTao,
   'www.empornium.is': _freeLuminance,
   'www.empornium.sx': _freeLuminance,
   'www.pixelcove.me': _freeLuminance,


### PR DESCRIPTION
葡萄不在站点RSS设置里把大小加入种子标题的话，在vt就会获取失败。我修改了一下获取逻辑，让vt在这种情况下把种子大小设置为0而不是直接报错。