### PR TITLE
fix: 适配 qBittorrent 5.2.0 WebAPI 返回 204 的变更

### DIFF
--- a/app/common/Client.js
+++ b/app/common/Client.js
@@ -327,7 +327,7 @@ class Client {
       throw new Error('客户端' + this.alias + '当前状态为不可用');
     }
     const { statusCode } = await this.client.addTorrent(this.clientUrl, this.cookie, torrentUrl, isSkipChecking, uploadLimit, downloadLimit, savePath, category, autoTMM, this.firstLastPiecePrio, paused);
-    if (statusCode !== 200) {
+    if (statusCode !== 200 && statusCode !== 204) {
       this.login();
       throw new Error('状态码: ' + statusCode);
     }
@@ -346,7 +346,7 @@ class Client {
 
   async addTorrentByTorrentFile (filepath, hash, isSkipChecking = false, uploadLimit = 0, downloadLimit = 0, savePath, category, autoTMM, paused) {
     const { statusCode } = await this.client.addTorrentByTorrentFile(this.clientUrl, this.cookie, filepath, isSkipChecking, uploadLimit, downloadLimit, savePath, category, autoTMM, this.firstLastPiecePrio, paused);
-    if (statusCode !== 200) {
+    if (statusCode !== 200 && statusCode !== 204) {
       this.login();
       throw new Error('状态码: ' + statusCode);
     }

--- a/app/libs/client/qb.js
+++ b/app/libs/client/qb.js
@@ -13,7 +13,10 @@ exports.login = async function (username, clientUrl, password) {
     }
   };
   const res = await util.requestPromise(message);
-  if (res.body.indexOf('Ok') !== -1) {
+  // qBittorrent 5.2.0+ returns 204 No Content with empty body on successful login;
+  // older versions return 200 with body "Ok." / "Fails.".
+  const loginOk = res.statusCode === 204 || (res.body && res.body.indexOf('Ok') !== -1);
+  if (loginOk && res.headers['set-cookie'] && res.headers['set-cookie'][0]) {
     Object.keys(apiVersionCache).forEach(key => {
       if (key.startsWith(clientUrl)) {
         delete apiVersionCache[key];
@@ -21,7 +24,7 @@ exports.login = async function (username, clientUrl, password) {
     });
     return res.headers['set-cookie'][0].substring(0, res.headers['set-cookie'][0].indexOf(';'));
   }
-  if (res.body.indexOf('Fails') !== -1) {
+  if (res.body && res.body.indexOf('Fails') !== -1) {
     throw new Error('password is wrong!');
   }
   if (res.statusCode !== 200) {


### PR DESCRIPTION
qBittorrent 5.2.0 changelog: "WEBAPI: Send 204 when WebAPI response contains no data"。 登录与加种成功的响应不再是 200 + "Ok." 而是 204 No Content，原有的
res.body.indexOf("Ok") 与 statusCode !== 200 校验会把成功误判为失败， 导致下载器连接失败 (Issue #108)。

- qb.js: 登录同时接受 204 与旧版 200 + "Ok." 两种成功形式， 并对 set-cookie 缺失情况加保护。
- Client.js: addTorrent / addTorrentByTorrentFile 的 statusCode 校验 追加 204 为成功。

其余仍返回 JSON 数据的端点 (getMaindata / getTrackerList 等) 不受 5.2.0 影响，未做修改；旧版 qBittorrent 行为保持兼容。